### PR TITLE
Enable DC in registered device to use HIGH value

### DIFF
--- a/simcir-basicset.js
+++ b/simcir-basicset.js
@@ -658,14 +658,14 @@
   // register direct current source
   $s.registerDevice('DC', function(device) {
     device.addOutput();
+    device.getOutputs()[0].setValue(onValue);  // Enable DC on default.
     var super_createUI = device.createUI;
     device.createUI = function() {
       super_createUI();
       device.$ui.addClass('simcir-basicset-dc');
     };
-    device.$ui.on('deviceAdd', function() {
-      device.getOutputs()[0].setValue(onValue);
-    });
+    //device.$ui.on('deviceAdd', function() {
+    //});
     device.$ui.on('deviceRemove', function() {
       device.getOutputs()[0].setValue(null);
     });


### PR DESCRIPTION
It is convenient to enable HIGH value in registered device,
To achieve this, set default value of DC to HIGH.

Fix #13